### PR TITLE
Patch 1: Clearer part construction in parser

### DIFF
--- a/src/Music/Chart/Parsers.elm
+++ b/src/Music/Chart/Parsers.elm
@@ -54,16 +54,26 @@ chart =
 part : Parser Part
 part =
     inContext "part" <|
-        succeed (\partName toPart -> toPart partName)
+        succeed asPart
             |. symbol "="
             |. spaces
             |= keepUntilEndOfLine
             |. spacesAndNewlines
             |= oneOf
-                [ succeed (\bars partName -> Part partName bars)
+                [ succeed Just
                     |= repeat oneOrMore (bar |. spacesAndNewlines)
-                , succeed PartRepeat
+                , succeed Nothing
                 ]
+
+
+asPart : String -> Maybe (List Bar) -> Part
+asPart name bars =
+    case bars of
+        Nothing ->
+            PartRepeat name
+
+        Just b ->
+            Part name b
 
 
 bar : Parser Bar


### PR DESCRIPTION
I was a bit confused about the construction of parts in the parsing module. I made a patch, but I am not sure if you like it.

Instead having the lambdas with multiple arguments, a single function is now used which takes the list of bars or nothing and decides which kind of `Part` should be constructed.